### PR TITLE
Upgrade parser_tools to support duckdb 1.4.0

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -22,8 +22,8 @@ jobs:
 
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.3.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.0
     with:
-      duckdb_version: v1.3.0
-      ci_tools_version: v1.3.0
+      duckdb_version: v1.4.0
+      ci_tools_version: v1.4.0
       extension_name: parser_tools

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,13 +12,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-#  duckdb-next-build:
-#    name: Build extension binaries
-#    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
-#    with:
-#      duckdb_version: main
-#      ci_tools_version: main
-#      extension_name: parser_tools
+  duckdb-next-build:
+   name: Build extension binaries
+   uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
+   with:
+     duckdb_version: main
+     ci_tools_version: main
+     extension_name: parser_tools
 
   duckdb-stable-build:
     name: Build extension binaries

--- a/src/include/parse_functions.hpp
+++ b/src/include/parse_functions.hpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 // Forward declarations
-class DatabaseInstance;
+class ExtensionLoader;
 
 struct FunctionResult {
 	std::string function_name;
@@ -15,7 +15,7 @@ struct FunctionResult {
 	std::string context;     // The context where this function appears (SELECT, WHERE, etc.)
 };
 
-void RegisterParseFunctionsFunction(DatabaseInstance &db);
-void RegisterParseFunctionScalarFunction(DatabaseInstance &db);
+void RegisterParseFunctionsFunction(ExtensionLoader &loader);
+void RegisterParseFunctionScalarFunction(ExtensionLoader &loader);
 
 } // namespace duckdb

--- a/src/include/parse_tables.hpp
+++ b/src/include/parse_tables.hpp
@@ -33,7 +33,7 @@ static void ExtractTablesFromQueryNode(
     const duckdb::CommonTableExpressionMap *cte_map = nullptr
 );
 
-void RegisterParseTablesFunction(duckdb::DatabaseInstance &db);
-void RegisterParseTableScalarFunction(DatabaseInstance &db);
+void RegisterParseTablesFunction(duckdb::ExtensionLoader &loader);
+void RegisterParseTableScalarFunction(ExtensionLoader &loader);
 
 } // namespace duckdb

--- a/src/include/parse_where.hpp
+++ b/src/include/parse_where.hpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 // Forward declarations
-class DatabaseInstance;
+class ExtensionLoader;
 
 struct WhereConditionResult {
     std::string condition;
@@ -23,8 +23,8 @@ struct DetailedWhereConditionResult {
     std::string context;        // The context where this condition appears (WHERE, HAVING, etc.)
 };
 
-void RegisterParseWhereFunction(DatabaseInstance &db);
-void RegisterParseWhereScalarFunction(DatabaseInstance &db);
-void RegisterParseWhereDetailedFunction(DatabaseInstance &db);
+void RegisterParseWhereFunction(ExtensionLoader &loader);
+void RegisterParseWhereScalarFunction(ExtensionLoader &loader);
+void RegisterParseWhereDetailedFunction(ExtensionLoader &loader);
 
 } // namespace duckdb 

--- a/src/include/parser_tools_extension.hpp
+++ b/src/include/parser_tools_extension.hpp
@@ -6,7 +6,7 @@ namespace duckdb {
 
 class ParserToolsExtension : public Extension {
 public:
-	void Load(DuckDB &db) override;
+	void Load(ExtensionLoader &loader) override;
 	std::string Name() override;
 	std::string Version() const override;
 };

--- a/src/parse_functions.cpp
+++ b/src/parse_functions.cpp
@@ -7,7 +7,6 @@
 #include "duckdb/parser/expression/window_expression.hpp"
 #include "duckdb/parser/parsed_expression_iterator.hpp"
 #include "duckdb/parser/result_modifier.hpp"
-#include "duckdb/main/extension_util.hpp"
 #include "duckdb/function/scalar/nested_functions.hpp"
 
 
@@ -328,15 +327,15 @@ static void ParseFunctionsScalarFunction_struct(DataChunk &args, ExpressionState
 // Extension scaffolding
 // ---------------------------------------------------
 
-void RegisterParseFunctionsFunction(DatabaseInstance &db) {
+void RegisterParseFunctionsFunction(ExtensionLoader &loader) {
 	TableFunction tf("parse_functions", {LogicalType::VARCHAR}, ParseFunctionsFunction, ParseFunctionsBind, ParseFunctionsInit);
-	ExtensionUtil::RegisterFunction(db, tf);
+	loader.RegisterFunction(tf);
 }
 
-void RegisterParseFunctionScalarFunction(DatabaseInstance &db) {
+void RegisterParseFunctionScalarFunction(ExtensionLoader &loader) {
 	// parse_function_names is a scalar function that returns a list of function names
 	ScalarFunction sf("parse_function_names", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR), ParseFunctionNamesScalarFunction);
-	ExtensionUtil::RegisterFunction(db, sf);
+	loader.RegisterFunction(sf);
 
 	// parse_functions_struct is a scalar function that returns a list of structs
 	auto return_type = LogicalType::LIST(LogicalType::STRUCT({
@@ -345,7 +344,7 @@ void RegisterParseFunctionScalarFunction(DatabaseInstance &db) {
 		{"context", LogicalType::VARCHAR}
 	}));
 	ScalarFunction sf_struct("parse_functions", {LogicalType::VARCHAR}, return_type, ParseFunctionsScalarFunction_struct);
-	ExtensionUtil::RegisterFunction(db, sf_struct);
+	loader.RegisterFunction(sf_struct);
 }
 
 

--- a/src/parse_tables.cpp
+++ b/src/parse_tables.cpp
@@ -150,11 +150,6 @@ static void ExtractTablesFromQueryNode(
     else if (node.type == QueryNodeType::CTE_NODE) {
         auto &cte_node = (CTENode &)node;
 
-        // Extract tables from the CTE query definition
-        if (cte_node.query) {
-            ExtractTablesFromQueryNode(*cte_node.query, results, TableContext::From, cte_map);
-        }
-
         // Extract tables from the child query (the main query that uses the CTE)
         if (cte_node.child) {
             // Pass the existing CTE map to the child query

--- a/src/parse_tables.cpp
+++ b/src/parse_tables.cpp
@@ -145,15 +145,11 @@ static void ExtractTablesFromQueryNode(
             ExtractTablesFromRef(*select_node.from_table, results, context, true, &select_node.cte_map);
         }
     } 
-    // for ctes, we need an extra step to extract the cte body, and then the rest of the statement
-    // don't actually record any details from this node in the result otherwise it will be duplicated in the recursive calls below.
+    // additional step necessary for duckdb v1.4.0: unwrap CTE node
     else if (node.type == QueryNodeType::CTE_NODE) {
         auto &cte_node = (CTENode &)node;
 
-        // Extract tables from the child query (the main query that uses the CTE)
         if (cte_node.child) {
-            // Pass the existing CTE map to the child query
-            // The current CTE will be available for reference in the child
             ExtractTablesFromQueryNode(*cte_node.child, results, context, cte_map);
         }
     }

--- a/src/parse_where.cpp
+++ b/src/parse_where.cpp
@@ -19,7 +19,6 @@
 #include "duckdb/parser/expression/positional_reference_expression.hpp"
 #include "duckdb/parser/expression/parameter_expression.hpp"
 #include "duckdb/parser/tableref/basetableref.hpp"
-#include "duckdb/main/extension_util.hpp"
 
 namespace duckdb {
 
@@ -236,19 +235,19 @@ static void ParseWhereScalarFunction(DataChunk &args, ExpressionState &state, Ve
     });
 }
 
-void RegisterParseWhereFunction(DatabaseInstance &db) {
+void RegisterParseWhereFunction(ExtensionLoader &loader) {
     TableFunction tf("parse_where", {LogicalType::VARCHAR}, ParseWhereFunction, ParseWhereBind, ParseWhereInit);
-    ExtensionUtil::RegisterFunction(db, tf);
+    loader.RegisterFunction(tf);
 }
 
-void RegisterParseWhereScalarFunction(DatabaseInstance &db) {
+void RegisterParseWhereScalarFunction(ExtensionLoader &loader) {
     auto return_type = LogicalType::LIST(LogicalType::STRUCT({
         {"condition", LogicalType::VARCHAR},
         {"table_name", LogicalType::VARCHAR},
         {"context", LogicalType::VARCHAR}
     }));
     ScalarFunction sf("parse_where", {LogicalType::VARCHAR}, return_type, ParseWhereScalarFunction);
-    ExtensionUtil::RegisterFunction(db, sf);
+    loader.RegisterFunction(sf);
 }
 
 static string DetailedExpressionTypeToOperator(ExpressionType type) {
@@ -476,9 +475,9 @@ static void ParseWhereDetailedFunction(ClientContext &context,
     state.row++;
 }
 
-void RegisterParseWhereDetailedFunction(DatabaseInstance &db) {
+void RegisterParseWhereDetailedFunction(ExtensionLoader &loader) {
     TableFunction tf("parse_where_detailed", {LogicalType::VARCHAR}, ParseWhereDetailedFunction, ParseWhereDetailedBind, ParseWhereDetailedInit);
-    ExtensionUtil::RegisterFunction(db, tf);
+    loader.RegisterFunction(tf);
 }
 
 } // namespace duckdb 

--- a/src/parser_tools_extension.cpp
+++ b/src/parser_tools_extension.cpp
@@ -56,11 +56,4 @@ DUCKDB_CPP_EXTENSION_ENTRY(parser_tools, loader) {
     duckdb::LoadInternal(loader);
 }
 
-DUCKDB_EXTENSION_API const char *parser_tools_version() {
-	return duckdb::DuckDB::LibraryVersion();
 }
-}
-
-#ifndef DUCKDB_EXTENSION_MAIN
-#error DUCKDB_EXTENSION_MAIN not defined
-#endif

--- a/src/parser_tools_extension.cpp
+++ b/src/parser_tools_extension.cpp
@@ -22,18 +22,18 @@ namespace duckdb {
 // ---------------------------------------------------
 // EXTENSION SCAFFOLDING
 
-static void LoadInternal(DatabaseInstance &instance) {
-    RegisterParseTablesFunction(instance);
-	RegisterParseTableScalarFunction(instance);
-	RegisterParseWhereFunction(instance);
-	RegisterParseWhereScalarFunction(instance);
-	RegisterParseWhereDetailedFunction(instance);
-	RegisterParseFunctionsFunction(instance);
-	RegisterParseFunctionScalarFunction(instance);
+static void LoadInternal(ExtensionLoader &loader) {
+    RegisterParseTablesFunction(loader);
+	RegisterParseTableScalarFunction(loader);
+	RegisterParseWhereFunction(loader);
+	RegisterParseWhereScalarFunction(loader);
+	RegisterParseWhereDetailedFunction(loader);
+	RegisterParseFunctionsFunction(loader);
+	RegisterParseFunctionScalarFunction(loader);
 }
 
-void ParserToolsExtension::Load(DuckDB &db) {
-	LoadInternal(*db.instance);
+void ParserToolsExtension::Load(ExtensionLoader &loader) {
+	LoadInternal(loader);
 }
 
 std::string ParserToolsExtension::Name() {
@@ -52,9 +52,8 @@ std::string ParserToolsExtension::Version() const {
 
 extern "C" {
 
-DUCKDB_EXTENSION_API void parser_tools_init(duckdb::DatabaseInstance &db) {
-    duckdb::DuckDB db_wrapper(db);
-    db_wrapper.LoadExtension<duckdb::ParserToolsExtension>();
+DUCKDB_CPP_EXTENSION_ENTRY(parser_tools, loader) {
+    duckdb::LoadInternal(loader);
 }
 
 DUCKDB_EXTENSION_API const char *parser_tools_version() {


### PR DESCRIPTION
Resolves #6.

In addition to the minor scaffolding changes mentioned in #6, there were (apparently) changes to the Parser. CTE expressions now come back with a wrapper CTE_NODE QueryNodeType. The code was updated to support this change. 