### PR TITLE
Add statement parsing functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,12 @@ set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 project(${TARGET_NAME})
 include_directories(src/include)
 
-set(EXTENSION_SOURCES 
+set(EXTENSION_SOURCES
   src/parser_tools_extension.cpp
   src/parse_tables.cpp
   src/parse_where.cpp
   src/parse_functions.cpp
+  src/parse_statements.cpp
 )
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})

--- a/src/include/parse_statements.hpp
+++ b/src/include/parse_statements.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// Forward declarations
+class ExtensionLoader;
+
+struct StatementResult {
+	std::string statement;
+};
+
+void RegisterParseStatementsFunction(ExtensionLoader &loader);
+void RegisterParseStatementsScalarFunction(ExtensionLoader &loader);
+
+} // namespace duckdb

--- a/src/parse_statements.cpp
+++ b/src/parse_statements.cpp
@@ -1,0 +1,145 @@
+#include "parse_statements.hpp"
+#include "duckdb.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/select_statement.hpp"
+#include "duckdb/function/scalar/nested_functions.hpp"
+
+namespace duckdb {
+
+struct ParseStatementsState : public GlobalTableFunctionState {
+	idx_t row = 0;
+	vector<StatementResult> results;
+};
+
+struct ParseStatementsBindData : public TableFunctionData {
+	string sql;
+};
+
+// BIND function: runs during query planning to decide output schema
+static unique_ptr<FunctionData> ParseStatementsBind(ClientContext &context,
+													TableFunctionBindInput &input,
+													vector<LogicalType> &return_types,
+													vector<string> &names) {
+
+	string sql_input = StringValue::Get(input.inputs[0]);
+
+	// Return single column with statement text
+	return_types = {LogicalType::VARCHAR};
+	names = {"statement"};
+
+	// Create a bind data object to hold the SQL input
+	auto result = make_uniq<ParseStatementsBindData>();
+	result->sql = sql_input;
+
+	return std::move(result);
+}
+
+// INIT function: runs before table function execution
+static unique_ptr<GlobalTableFunctionState> ParseStatementsInit(ClientContext &context,
+																TableFunctionInitInput &input) {
+	return make_uniq<ParseStatementsState>();
+}
+
+static void ExtractStatementsFromSQL(const std::string &sql, std::vector<StatementResult> &results) {
+	Parser parser;
+
+	try {
+		parser.ParseQuery(sql);
+	} catch (const ParserException &ex) {
+		// Swallow parser exceptions to make this function more robust
+		return;
+	}
+
+	for (auto &stmt : parser.statements) {
+		if (stmt) {
+			// Convert statement back to string
+			auto statement_str = stmt->ToString();
+			results.push_back(StatementResult{statement_str});
+		}
+	}
+}
+
+static void ParseStatementsFunction(ClientContext &context,
+								   TableFunctionInput &data,
+								   DataChunk &output) {
+	auto &state = (ParseStatementsState &)*data.global_state;
+	auto &bind_data = (ParseStatementsBindData &)*data.bind_data;
+
+	if (state.results.empty() && state.row == 0) {
+		ExtractStatementsFromSQL(bind_data.sql, state.results);
+	}
+
+	if (state.row >= state.results.size()) {
+		return;
+	}
+
+	auto &stmt = state.results[state.row];
+	output.SetCardinality(1);
+	output.SetValue(0, 0, Value(stmt.statement));
+
+	state.row++;
+}
+
+static void ParseStatementsScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<string_t, list_entry_t>(args.data[0], result, args.size(),
+	[&result](string_t query) -> list_entry_t {
+		// Parse the SQL query and extract statements
+		auto query_string = query.GetString();
+		std::vector<StatementResult> parsed_statements;
+		ExtractStatementsFromSQL(query_string, parsed_statements);
+
+		auto current_size = ListVector::GetListSize(result);
+		auto number_of_statements = parsed_statements.size();
+		auto new_size = current_size + number_of_statements;
+
+		// Grow list if needed
+		if (ListVector::GetListCapacity(result) < new_size) {
+			ListVector::Reserve(result, new_size);
+		}
+
+		// Write the statements into the child vector
+		auto statements = FlatVector::GetData<string_t>(ListVector::GetEntry(result));
+		for (size_t i = 0; i < parsed_statements.size(); i++) {
+			auto &stmt = parsed_statements[i];
+			statements[current_size + i] = StringVector::AddStringOrBlob(ListVector::GetEntry(result), stmt.statement);
+		}
+
+		// Update size
+		ListVector::SetListSize(result, new_size);
+
+		return list_entry_t(current_size, number_of_statements);
+	});
+}
+
+static void NumStatementsScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	UnaryExecutor::Execute<string_t, int64_t>(args.data[0], result, args.size(),
+	[](string_t query) -> int64_t {
+		// Parse the SQL query and count statements
+		auto query_string = query.GetString();
+		std::vector<StatementResult> parsed_statements;
+		ExtractStatementsFromSQL(query_string, parsed_statements);
+
+		return static_cast<int64_t>(parsed_statements.size());
+	});
+}
+
+// Extension scaffolding
+// ---------------------------------------------------
+
+void RegisterParseStatementsFunction(ExtensionLoader &loader) {
+	// Table function that returns one row per statement
+	TableFunction tf("parse_statements", {LogicalType::VARCHAR}, ParseStatementsFunction, ParseStatementsBind, ParseStatementsInit);
+	loader.RegisterFunction(tf);
+}
+
+void RegisterParseStatementsScalarFunction(ExtensionLoader &loader) {
+	// parse_statements is a scalar function that returns a list of statement strings
+	ScalarFunction sf("parse_statements", {LogicalType::VARCHAR}, LogicalType::LIST(LogicalType::VARCHAR), ParseStatementsScalarFunction);
+	loader.RegisterFunction(sf);
+
+	// num_statements is a scalar function that returns the count of statements
+	ScalarFunction num_sf("num_statements", {LogicalType::VARCHAR}, LogicalType::BIGINT, NumStatementsScalarFunction);
+	loader.RegisterFunction(num_sf);
+}
+
+} // namespace duckdb

--- a/src/parser_tools_extension.cpp
+++ b/src/parser_tools_extension.cpp
@@ -4,6 +4,7 @@
 #include "parse_tables.hpp"
 #include "parse_where.hpp"
 #include "parse_functions.hpp"
+#include "parse_statements.hpp"
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -30,6 +31,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterParseWhereDetailedFunction(loader);
 	RegisterParseFunctionsFunction(loader);
 	RegisterParseFunctionScalarFunction(loader);
+	RegisterParseStatementsFunction(loader);
+	RegisterParseStatementsScalarFunction(loader);
 }
 
 void ParserToolsExtension::Load(ExtensionLoader &loader) {

--- a/test/sql/parse_tools/scalar_functions/num_statements.test
+++ b/test/sql/parse_tools/scalar_functions/num_statements.test
@@ -1,0 +1,79 @@
+# name: test/sql/parser_tools/scalar_functions/num_statements.test
+# description: test num_statements scalar function
+# group: [num_statements]
+
+# Before we load the extension, this will fail
+statement error
+SELECT num_statements('SELECT 42; SELECT 43;');
+----
+Catalog Error: Scalar Function with name num_statements does not exist!
+
+# Require statement will ensure this test is run with this extension loaded
+require parser_tools
+
+# Single statement
+query I
+SELECT num_statements('SELECT 42;');
+----
+1
+
+# Two statements
+query I
+SELECT num_statements('SELECT 42; SELECT 43;');
+----
+2
+
+# Three statements
+query I
+SELECT num_statements('SELECT 1; SELECT 2; SELECT 3;');
+----
+3
+
+# Multiple statements with different types
+query I
+SELECT num_statements('SELECT 1; INSERT INTO test VALUES (2); UPDATE test SET x = 1; SELECT 3;');
+----
+4
+
+# Complex multi-statement query
+query I
+SELECT num_statements($$
+    WITH cte AS (SELECT 1 as a) SELECT * FROM cte;
+    SELECT upper('hello');
+    SELECT count(*) FROM users WHERE id > 10;
+    INSERT INTO log VALUES ('done');
+$$);
+----
+4
+
+# Single complex statement
+query I
+SELECT num_statements($$
+    WITH cte1 AS (SELECT * FROM table1),
+         cte2 AS (SELECT * FROM table2)
+    SELECT cte1.id, cte2.name
+    FROM cte1
+    JOIN cte2 ON cte1.id = cte2.id
+    WHERE cte1.active = true
+    ORDER BY cte1.created_at DESC;
+$$);
+----
+1
+
+# Empty input
+query I
+SELECT num_statements('');
+----
+0
+
+# Whitespace only
+query I
+SELECT num_statements('   ');
+----
+0
+
+# Invalid SQL should return 0
+query I
+SELECT num_statements('INVALID SQL SYNTAX HERE');
+----
+0

--- a/test/sql/parse_tools/scalar_functions/parse_statements.test
+++ b/test/sql/parse_tools/scalar_functions/parse_statements.test
@@ -1,0 +1,64 @@
+# name: test/sql/parser_tools/scalar_functions/parse_statements.test
+# description: test parse_statements scalar function
+# group: [parse_statements]
+
+# Before we load the extension, this will fail
+statement error
+SELECT parse_statements('SELECT 42; SELECT 43;');
+----
+Catalog Error: Scalar Function with name parse_statements does not exist!
+
+# Require statement will ensure this test is run with this extension loaded
+require parser_tools
+
+# Single statement
+query I
+SELECT parse_statements('SELECT 42;');
+----
+[SELECT 42]
+
+# Multiple statements
+query I
+SELECT parse_statements('SELECT 42; SELECT 43;');
+----
+[SELECT 42, SELECT 43]
+
+# Three statements
+query I
+SELECT parse_statements('SELECT 1; SELECT 2; SELECT 3;');
+----
+[SELECT 1, SELECT 2, SELECT 3]
+
+# Multiple statements with different types
+query I
+SELECT parse_statements('SELECT 1; INSERT INTO test VALUES (2); SELECT 3;');
+----
+[SELECT 1, 'INSERT INTO test (VALUES (2))', SELECT 3]
+
+# Complex multi-statement query
+query I
+SELECT parse_statements($$
+    WITH cte AS (SELECT 1 as a) SELECT * FROM cte;
+    SELECT upper('hello');
+    SELECT count(*) FROM users WHERE id > 10;
+$$);
+----
+['WITH cte AS (SELECT 1 AS a)SELECT * FROM cte', 'SELECT upper(\'hello\')', 'SELECT count_star() FROM users WHERE (id > 10)']
+
+# Empty input
+query I
+SELECT parse_statements('');
+----
+[]
+
+# Whitespace only
+query I
+SELECT parse_statements('   ');
+----
+[]
+
+# Invalid SQL should return empty list
+query I
+SELECT parse_statements('INVALID SQL SYNTAX HERE');
+----
+[]

--- a/test/sql/parse_tools/table_functions/parse_statements.test
+++ b/test/sql/parse_tools/table_functions/parse_statements.test
@@ -1,0 +1,70 @@
+# name: test/sql/parser_tools/table_functions/parse_statements.test
+# description: test parse_statements table function
+# group: [parse_statements]
+
+# Before we load the extension, this will fail
+statement error
+SELECT * FROM parse_statements('SELECT 42; SELECT 43;');
+----
+Catalog Error: Table Function with name parse_statements does not exist!
+
+# Require statement will ensure this test is run with this extension loaded
+require parser_tools
+
+# Single statement
+query I
+SELECT * FROM parse_statements('SELECT 42;');
+----
+SELECT 42
+
+# Multiple statements
+query I
+SELECT * FROM parse_statements('SELECT 42; SELECT 43;');
+----
+SELECT 42
+SELECT 43
+
+# Multiple statements with different types
+query I
+SELECT * FROM parse_statements('SELECT 1; INSERT INTO test VALUES (2); SELECT 3;');
+----
+SELECT 1
+INSERT INTO test (VALUES (2))
+SELECT 3
+
+# Complex multi-statement query
+query I
+SELECT * FROM parse_statements($$
+    WITH cte AS (SELECT 1 as a) SELECT * FROM cte;
+    SELECT upper('hello');
+    SELECT count(*) FROM users WHERE id > 10;
+$$);
+----
+WITH cte AS (SELECT 1 AS a)SELECT * FROM cte
+SELECT upper('hello')
+SELECT count_star() FROM users WHERE (id > 10)
+
+# Statements with CTEs and joins
+query I
+SELECT * FROM parse_statements($$
+    SELECT a.id FROM table_a a JOIN table_b b ON a.id = b.id;
+    WITH data AS (SELECT * FROM source) SELECT count(*) FROM data;
+$$);
+----
+SELECT a.id FROM table_a AS a INNER JOIN table_b AS b ON ((a.id = b.id))
+WITH "data" AS (SELECT * FROM "source")SELECT count_star() FROM "data"
+
+# Empty input
+query I
+SELECT * FROM parse_statements('');
+----
+
+# Whitespace only
+query I
+SELECT * FROM parse_statements('   ');
+----
+
+# Invalid SQL should return no results
+query I
+SELECT * FROM parse_statements('INVALID SQL SYNTAX HERE');
+----


### PR DESCRIPTION
Implements parse_statements() table and scalar functions, and num_statements() scalar function to parse multi-statement SQL strings. The functions extract individual statements or count them using DuckDB's native parser.

Resolves #8 .
