### PR TITLE
[DuckDb v1.5.0] fix: update SetOperationNode API for DuckDB main branch

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,19 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # TODO: Re-enable once compatible with DuckDB main (SetOperationNode API change)
-  # duckdb-next-build:
-  #  name: Build extension binaries
-  #  uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
-  #  with:
-  #    duckdb_version: main
-  #    ci_tools_version: main
-  #    extension_name: parser_tools
-
-  duckdb-stable-build:
+  duckdb-next-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.4
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: v1.4.4
-      ci_tools_version: v1.4.4
+      duckdb_version: main
+      ci_tools_version: main
       extension_name: parser_tools

--- a/src/parse_tables.cpp
+++ b/src/parse_tables.cpp
@@ -228,11 +228,10 @@ static void ExtractTablesFromQueryNode(
     else if (node.type == QueryNodeType::SET_OPERATION_NODE) {
         auto &set_node = (SetOperationNode &)node;
 
-        if (set_node.left) {
-            ExtractTablesFromQueryNode(*set_node.left, results, context, cte_map);
-        }
-        if (set_node.right) {
-            ExtractTablesFromQueryNode(*set_node.right, results, context, cte_map);
+        for (auto &child : set_node.children) {
+            if (child) {
+                ExtractTablesFromQueryNode(*child, results, context, cte_map);
+            }
         }
     }
 


### PR DESCRIPTION
Use children vector instead of left/right members to support the DuckDB v1.5+ API change.

**NOTE**: This change is not ready to merge. it's preparing parser_tools for the next (breaking change) version of duckdb, as discovered [here](https://github.com/hotdata-dev/duckdb_extension_parser_tools/actions/runs/21497648333/job/61936461494). Once 1.5.0 is released:

Update .github/workflows/MainDistributionPipeline.yml on this branch:
    - Change duckdb_version: main → duckdb_version: v1.5.x
    - Change ci_tools_version: main → ci_tools_version: v1.5.x
    - Change uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main → @v1.5.x